### PR TITLE
issues while packaging for bioconda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc 
 
-CFLAGS = -Wall -D_GNU_SOURCE
+CFLAGS = -Wall -D_GNU_SOURCE -fcommon
 LFLAGS = -lm
 
 ifeq ($(mode), debug)

--- a/RogueNaRok.c
+++ b/RogueNaRok.c
@@ -2216,6 +2216,10 @@ int main(int argc, char *argv[])
 	  break;
 	}
       case 'h':
+        {
+          printHelpFile();
+          exit(0);
+        }
       default:	
 	{
 	  printHelpFile();

--- a/rnr-lsi.c
+++ b/rnr-lsi.c
@@ -369,6 +369,10 @@ int main(int argc, char *argv[])
 	  excludeFile = optarg;
 	  break;
 	case 'h':
+          {
+            printHelpFile();
+            exit(0);
+          }
 	default: 
 	  {
 	    printHelpFile();

--- a/rnr-mast.c
+++ b/rnr-mast.c
@@ -926,6 +926,10 @@ int main(int argc, char *argv[])
 	  strcpy(workdir, optarg);
 	  break;
 	case 'h':
+          {
+            printHelpFile();
+            exit(0);
+          }
 	default:	
 	  {
 	    printHelpFile();

--- a/rnr-prune.c
+++ b/rnr-prune.c
@@ -185,7 +185,11 @@ int main(int argc, char *argv[])
 	case 'x':	  
 	  excludeFileName = optarg;
 	  break;
-	case 'h': 
+	case 'h':
+          {
+            printHelpFile();
+            exit(0);
+          }
 	default:
 	  {
 	    printHelpFile();

--- a/rnr-tii.c
+++ b/rnr-tii.c
@@ -290,6 +290,10 @@ int main(int argc, char *argv[])
 	  tiiZ = wrapStrToL(optarg); 
 	  break;
 	case 'h':
+          {
+            printHelpFile();
+            exit(0);
+          }
 	default:	
 	  {
 	    printHelpFile();


### PR DESCRIPTION
I'm packaging RogueNaRok for [bioconda](https://bioconda.github.io) because it is a requirement for another program I'm packaging.  I ran into two issues which are easy enough to patch for bioconda, but which I thought might be worth contributing back upstream as well.

1. At some point the default for gcc changed from `-fcommon` to `-fno-common`.  This causes `multiple definition` errors when linking RogueNaRok. The easy fix was to add `-fcommon` to `CFLAGS`.
2. All of the executables were using `abort()` instead of `exit(0)` when given the `-h` flag, leading to `Aborted (core dumped)`.  This may be confusing for users who think something is going wrong, and it also makes it hard to make minimal tests that all programs can be executed.  I changed the behavior to `exit(0)`.